### PR TITLE
fix: explicitly pass HEIMDALLR_TOKEN to heimdallr workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,8 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    secrets: inherit
+    secrets:
+      HEIMDALLR_TOKEN: ${{ secrets.HEIMDALLR_TOKEN }}
     with:
       enable_slack: ${{ github.event_name != 'pull_request' }}
       enable_comment_on_pr: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Fixes the github-token error in heimdallr pr_comment action.

Changes secrets: inherit to explicitly pass HEIMDALLR_TOKEN so the heimdallr workflow receives it properly.