### PR TITLE
fix: use token fallback in heimdallr + restore secrets inherit

### DIFF
--- a/.github/workflows/heimdallr.yml
+++ b/.github/workflows/heimdallr.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.HEIMDALLR_TOKEN }}
+          github-token: ${{ secrets.HEIMDALLR_TOKEN || github.token }}
           script: |
             function getPR(response,context) {
               if ( context.eventName === 'pull_request' ) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    secrets:
-      HEIMDALLR_TOKEN: ${{ secrets.HEIMDALLR_TOKEN }}
+    secrets: inherit
     with:
       enable_slack: ${{ github.event_name != 'pull_request' }}
       enable_comment_on_pr: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Problem
The previous fix broke Slack notifications by only passing HEIMDALLR_TOKEN instead of all secrets.

## Solution
1. **Revert release.yml** to use `secrets: inherit` - this passes ALL secrets (Slack + Heimdallr)
2. **Update heimdallr.yml** to use `secrets.HEIMDALLR_TOKEN || github.token` - falls back to default token if custom token not available

## Benefits  
- ✅ Slack notifications work again (has access to Slack secrets)
- ✅ Works with HEIMDALLR_TOKEN when available (Mosher-Labs orgs)
- ✅ Falls back to github.token for repos without HEIMDALLR_TOKEN (like appdiscr)
- ✅ Single fix works for all scenarios