### PR TITLE
fix(heimdallr): remove github.token fallback, require service account

### DIFF
--- a/.github/workflows/heimdallr.yml
+++ b/.github/workflows/heimdallr.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.HEIMDALLR_TOKEN || github.token }}
+          github-token: ${{ secrets.HEIMDALLR_TOKEN }}
           script: |
             function getPR(response,context) {
               if ( context.eventName === 'pull_request' ) {


### PR DESCRIPTION
## Summary

- Removes `|| github.token` fallback from heimdallr workflow
- Ensures HEIMDALLR_TOKEN (service account) is used exclusively for PR comments
- Maintains proper attribution with service account gravatar and username

## Changes

- Modified `.github/workflows/heimdallr.yml` line 69 to use only `secrets.HEIMDALLR_TOKEN`
- Removed fallback to `github.token` which doesn't provide proper identity attribution

## Context

When using `github.token` as a fallback, PR comments appear with the default GitHub Actions bot identity instead of the service account's identity (gravatar, username). This change ensures we always use the service account for proper attribution.

## Test Plan

- [ ] Verify HEIMDALLR_TOKEN is set as org secret in appdiscr
- [ ] Test PR comment on appdiscr repos to ensure service account identity is used
- [ ] Verify error is clear if HEIMDALLR_TOKEN is not available

🤖 Generated with [Claude Code](https://claude.com/claude-code)