### PR TITLE
fix(release): accept secrets in workflow_call for cross-org usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,13 @@ on:
         required: false
         type: boolean
         default: true
+    secrets:
+      HEIMDALLR_TOKEN:
+        required: false
+      SLACK_BOT_USER_OAUTH_ACCESS_TOKEN:
+        required: false
+      SLACK_PLATFORM_NOTIFICATIONS_CHANNEL_ID:
+        required: false
     outputs:
       next_version:
         value: ${{ jobs.release.outputs.next_version }}


### PR DESCRIPTION
## Summary

- Adds explicit `secrets:` section to release.yml workflow_call trigger
- Accepts HEIMDALLR_TOKEN and Slack secrets so they can be inherited
- Fixes cross-organization secret passing issue

## Root Cause

When a reusable workflow in one org (Mosher-Labs) is called from another org (appdiscr), `secrets: inherit` only works if the reusable workflow explicitly declares which secrets it accepts in the `workflow_call:` trigger.

Without this explicit declaration, secrets are not passed through, causing the "Input required and not supplied: github-token" error in the heimdallr workflow.

## Changes

Modified `.github/workflows/release.yml`:
- Added `secrets:` section under `workflow_call:`
- Declared HEIMDALLR_TOKEN, SLACK_BOT_USER_OAUTH_ACCESS_TOKEN, and SLACK_PLATFORM_NOTIFICATIONS_CHANNEL_ID as optional secrets

## Test Plan

- [ ] Merge this PR
- [ ] Re-run failed workflow on appdiscr/mobile PR #18
- [ ] Verify heimdallr pr_comment step succeeds with service account identity
- [ ] Confirm PR comment appears with proper attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)