### PR TITLE
fix: revert to working workflow configuration

### DIFF
--- a/.github/workflows/heimdallr.yml
+++ b/.github/workflows/heimdallr.yml
@@ -63,12 +63,6 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Debug secrets
-        run: |
-          echo "HEIMDALLR_TOKEN exists: ${{ secrets.HEIMDALLR_TOKEN != '' }}"
-          echo "HEIMDALLR_TOKEN length: ${#HEIMDALLR_TOKEN}"
-        env:
-          HEIMDALLR_TOKEN: ${{ secrets.HEIMDALLR_TOKEN }}
       - name: Comment on PR
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,6 @@ on:
         required: false
         type: boolean
         default: true
-    secrets:
-      HEIMDALLR_TOKEN:
-        required: false
-      SLACK_BOT_USER_OAUTH_ACCESS_TOKEN:
-        required: false
-      SLACK_PLATFORM_NOTIFICATIONS_CHANNEL_ID:
-        required: false
     outputs:
       next_version:
         value: ${{ jobs.release.outputs.next_version }}


### PR DESCRIPTION
Reverts the secret handling changes that broke HEIMDALLR_TOKEN.

**Root Cause:** Adding explicit `secrets:` declaration to `release.yml` workflow_call broke the implicit org secret passing that was working before.

**Changes:**
- Remove explicit secrets declaration from release.yml (reverts PR #50)
- Remove debug step from heimdallr.yml  
- Restores configuration from d4430be that was working

**Why this works:** Organization secrets work implicitly in reusable workflows when NOT explicitly declared in workflow_call.