### PR TITLE
chore(docs): add HEIMDALLR_TOKEN setup and rotation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,37 @@
 technologies, we deliver precision-crafted solutions with Amazon Web Services (AWS)
 and Infrastructure as Code (IaC). ⚡⚔️🌩️
 
+## 🔐 HEIMDALLR_TOKEN Setup
+
+The workflows use a GitHub Personal Access Token (PAT) for the `mosherlabs-heimdallr`
+service account to post PR comments with proper attribution.
+
+### Creating/Rotating the Token
+
+1. **Login to GitHub** as `mosherlabs-heimdallr` (credentials in 1Password)
+1. Go to **Settings** → **Developer settings** → **Personal access tokens** →
+   **Tokens (classic)**
+1. Click **Generate new token (classic)**
+1. **Token settings:**
+   - Note: `HEIMDALLR_TOKEN for Mosher-Labs`
+   - Expiration: 90 days (recommended)
+   - Scopes: `repo` (Full control of private repositories)
+1. **Generate token** and copy it immediately
+1. **Add to Mosher-Labs org:**
+
+   ```bash
+   echo "<token>" | gh secret set HEIMDALLR_TOKEN \
+     --org Mosher-Labs --visibility all
+   ```
+
+1. **Store in 1Password** under mosherlabs-heimdallr account for future reference
+
+### Why This Token
+
+- Provides proper attribution (gravatar, username) on PR comments
+- Shared across all Mosher-Labs repos via organization secret
+- Must be rotated every 90 days for security
+
 ## 🔰 Contributing
 
 Upon first clone, install the pre-commit hooks.


### PR DESCRIPTION
Adds documentation on how to create and rotate the HEIMDALLR_TOKEN for the mosherlabs-heimdallr service account. Prevents losing this knowledge in the future.