### PR TITLE
fix: add noNewCommitBehavior silent to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           token: ${{ github.token }}
           branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           noVersionBumpBehavior: "silent"
+          noNewCommitBehavior: "silent"
           skipInvalidTags: true
           patchList: fix, bugfix, perf, refactor, test, tests, chore
 


### PR DESCRIPTION
## Summary

- Add `noNewCommitBehavior: "silent"` to the semver-action in release.yml

## Problem

When HEAD is already tagged (e.g., after a manual initial release like v1.0.0),
the semver-action fails with:

```
Couldn't find any commits between branch HEAD and latest tag.
```

This causes the release workflow to fail even though there's nothing wrong -
there simply aren't any new commits to release.

## Solution

Adding `noNewCommitBehavior: "silent"` makes the workflow succeed silently
instead of failing when there are no new commits since the last tag.

## Test plan

- [ ] Verify CI passes
- [ ] After merge, re-run the failed release workflow on pre-commit-autoupdate

🤖 Generated with [Claude Code](https://claude.com/claude-code)