### PR TITLE
fix: support fork PRs in release workflow checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Checkout Code (Regular)
         if: github.event_name != 'pull_request'
@@ -57,7 +57,7 @@ jobs:
         uses: ietf-tools/semver-action@v1
         with:
           token: ${{ github.token }}
-          branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          branch: main
           noVersionBumpBehavior: "silent"
           noNewCommitBehavior: "silent"
           skipInvalidTags: true


### PR DESCRIPTION
## Summary
- Use `refs/pull/NUMBER/merge` for PR checkout instead of `github.event.pull_request.head.ref`
- Use `branch: main` for semver action since the merge ref includes PR commits

## Root Cause
The previous checkout used `github.event.pull_request.head.ref` (e.g., `fix/coverage-cache-paths`) which fails for fork PRs because that branch only exists in the fork repository, not the base repository.

## Changes
- **Checkout step**: Changed from `ref: ${{ github.event.pull_request.head.ref }}` to `ref: refs/pull/${{ github.event.pull_request.number }}/merge`
- **Semver step**: Changed from conditional branch selection to always use `main` (works because merge ref includes PR commits in main's history)

## Related
This fixes the checkout failure in PR #62 (from discrapp fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)