### PR TITLE
fix: pass Slack secrets to heimdallr workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,8 @@ jobs:
       pull-requests: write
     secrets:
       HEIMDALLR_TOKEN: ${{ secrets.HEIMDALLR_TOKEN }}
+      SLACK_BOT_USER_OAUTH_ACCESS_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+      SLACK_PLATFORM_NOTIFICATIONS_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_NOTIFICATIONS_CHANNEL_ID }}
     with:
       enable_slack: ${{ github.event_name != 'pull_request' }}
       enable_comment_on_pr: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary
- Pass `SLACK_BOT_USER_OAUTH_ACCESS_TOKEN` and `SLACK_PLATFORM_NOTIFICATIONS_CHANNEL_ID` secrets to the heimdallr workflow
- Fixes the slack notification job failing on pushes to main (when `enable_slack: true`)

## Test plan
- [ ] Verify PR passes checks
- [ ] Merge and confirm slack notification works on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)