### PR TITLE
fix: ensure chore/ci/build commits trigger patch releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           noVersionBumpBehavior: "silent"
           noNewCommitBehavior: "silent"
           skipInvalidTags: true
-          patchList: fix, bugfix, perf, refactor, test, tests, chore, ci
+          patchList: fix,bugfix,perf,refactor,test,tests,chore,ci,build
 
       - name: Create Release
         if: github.event_name != 'pull_request' && steps.semver.outputs.next != ''


### PR DESCRIPTION
## Summary
- Add `ci` and `build` to patchList for patch version bumps
- Remove spaces between patchList entries (whitespace sensitivity)

## Problem
`chore` and `chore(deps)` commits (e.g., from Renovate) were not triggering patch version bumps despite being in the patchList.

## Changes
```yaml
# Before
patchList: fix, bugfix, perf, refactor, test, tests, chore

# After  
patchList: fix,bugfix,perf,refactor,test,tests,chore,ci,build
```

## Test plan
- [ ] Merge this PR
- [ ] Create a test commit with `chore: test` or `chore(deps): test`
- [ ] Verify a patch version bump is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)