### PR TITLE
fix: use PR head ref for semver branch on pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ietf-tools/semver-action@v1
         with:
           token: ${{ github.token }}
-          branch: main
+          branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           noVersionBumpBehavior: "silent"
           noNewCommitBehavior: "silent"
           skipInvalidTags: true


### PR DESCRIPTION
## Summary

- The semver action was hardcoded to `branch: main`, so on PRs it found no new commits past the latest tag and silently exited
- Now dynamically sets the branch to the PR head ref on `pull_request` events, matching the discrapp version

## Test plan

- [ ] Verify Heimdallr comments the correct next version on PRs in repos using this workflow (e.g. Mosher-Labs/renewed#35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)